### PR TITLE
feat(observability): Alloy collector → Honcho VPS Loki (centralized log search)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ processes.json
 .hermes_history
 .skills_prompt_snapshot.json
 .update_check
+
+# Alloy log-collector runtime positions
+observability/data/

--- a/observability/README.md
+++ b/observability/README.md
@@ -1,0 +1,51 @@
+# observability/ — centralized log shipper
+
+Grafana Alloy collector that ships this box's logs to the **Honcho VPS Loki**
+over the tailnet, so the Hermes VPS shows up in the agent-memory plane's single
+pane of glass (Grafana) alongside the Mac Studio, Honcho VPS, and OpenClaw VPS.
+
+- **Central stack + decision**: [rh7/mac-studio-services#277](https://github.com/rh7/mac-studio-services/issues/277)
+- **What it ships**: the **system + user journals** (`hermes-gateway` runs as a
+  `--user` service with `StandardOutput=journal`) and all **docker container
+  logs** (e.g. the `:8081` routing proxy).
+- **Where it ships**: `http://100.122.214.76:3100/loki/api/v1/push` (Honcho VPS
+  tailnet IP). Override with `LOKI_PUSH_URL` if the IP drifts.
+
+## PII boundary
+
+The gateway journal can contain email/Signal/chat message content. The sink is
+the **self-hosted, tailnet-only Loki** with short retention — never a SaaS log
+product. Do not point `LOKI_PUSH_URL` at anything off the tailnet.
+
+## Prerequisites
+
+1. **Tailscale ACL** — `tag:agent-memory` (this box) must reach the Honcho VPS on
+   `:3100` (tracked in mac-studio-services `docs/tailscale-acl.md`).
+2. The **central Loki stack** must be live on the Honcho VPS (mac-studio-services
+   #277).
+3. **Persistent journald** so the `hermes-gateway` user-unit logs land in
+   `/var/log/journal`. Check `journalctl --disk-usage`; if this box only has
+   volatile journals, change the journal `path` in `config.alloy` to
+   `/run/log/journal`.
+
+## Install
+
+```bash
+# adjust WorkingDirectory in alloy.service to this repo's checkout path first
+sudo install -m 0644 observability/alloy.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now alloy
+# Manual fallback (no systemd):
+#   docker compose -f observability/docker-compose.yml up -d
+```
+
+## Verify
+
+```bash
+docker logs alloy --tail 30 | grep -i 'level=error' || echo "no errors"
+```
+Then in Grafana (on the Honcho VPS, via `tailscale serve`) → Explore → Loki:
+```logql
+{host="vps-hermes"}
+{host="vps-hermes", unit="hermes-gateway.service"}
+```

--- a/observability/alloy.service
+++ b/observability/alloy.service
@@ -1,0 +1,26 @@
+# systemd unit — supervises the Alloy log-collector docker-compose service.
+# Runs as root (system unit) so it can read /var/log/journal (incl. the user
+# journal where hermes-gateway logs) and the docker socket.
+#
+# Set WorkingDirectory to wherever this repo is checked out for docker services.
+#
+# Install:
+#   sudo install -m 0644 observability/alloy.service /etc/systemd/system/
+#   sudo systemctl daemon-reload && sudo systemctl enable --now alloy
+
+[Unit]
+Description=Alloy log collector (ships logs to the Honcho VPS Loki)
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/hermes-config/observability
+ExecStart=/usr/bin/docker compose up --abort-on-container-exit
+ExecStop=/usr/bin/docker compose down
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/observability/config.alloy
+++ b/observability/config.alloy
@@ -1,0 +1,67 @@
+// Grafana Alloy — Hermes VPS log collector. Ships this box's journald (system +
+// user) and docker container logs to the Honcho VPS Loki over the tailnet.
+//
+// Part of the agent-memory plane's centralized observability (single pane of
+// glass across Studio + the VPSes). Central stack + decision:
+// rh7/mac-studio-services#277.
+//
+// PII note: the Hermes gateway's journal can carry email/Signal/chat message
+// content. That's why the sink is the SELF-HOSTED, tailnet-only Loki (short
+// retention) — never a SaaS log product.
+
+logging {
+  level  = "info"
+  format = "logfmt"
+}
+
+// ---- journald: system + user units (hermes-gateway runs as a `--user` service,
+//      StandardOutput=journal → user journal) ----
+loki.relabel "journal" {
+  forward_to = []
+  rule {
+    source_labels = ["__journal__systemd_unit"]
+    target_label  = "unit"
+  }
+  rule {
+    source_labels = ["__journal__systemd_user_unit"]
+    target_label  = "unit"
+  }
+}
+
+loki.source.journal "all" {
+  // Persistent journal dir holds BOTH system.journal and user-<uid>.journal.
+  // If this box uses volatile journals only, change to "/run/log/journal".
+  path          = "/var/log/journal"
+  max_age       = "12h"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = { job = "journal", host = "vps-hermes" }
+  forward_to    = [loki.write.default.receiver]
+}
+
+// ---- docker container logs (e.g. the :8081 routing proxy) ----
+discovery.docker "containers" {
+  host = "unix:///var/run/docker.sock"
+}
+
+discovery.relabel "containers" {
+  targets = discovery.docker.containers.targets
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "service"
+  }
+}
+
+loki.source.docker "containers" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.relabel.containers.output
+  labels     = { job = "docker", host = "vps-hermes" }
+  forward_to = [loki.write.default.receiver]
+}
+
+loki.write "default" {
+  endpoint {
+    // Honcho VPS Loki, tailnet IP. Override via LOKI_PUSH_URL if the IP drifts.
+    url = coalesce(sys.env("LOKI_PUSH_URL"), "http://100.122.214.76:3100/loki/api/v1/push")
+  }
+}

--- a/observability/docker-compose.yml
+++ b/observability/docker-compose.yml
@@ -1,0 +1,34 @@
+# Alloy log collector — ships Hermes VPS logs to the Honcho VPS Loki over the
+# tailnet (centralized observability, rh7/mac-studio-services#277).
+#
+# No secrets: the push is unauthenticated over the tailnet (the Tailscale ACL is
+# the access boundary). The Honcho VPS Loki must allow tag:agent-memory → :3100.
+#
+# Start: docker compose -f observability/docker-compose.yml up -d
+# (or supervise via observability/alloy.service — see README.md)
+
+services:
+  alloy:
+    image: grafana/alloy:v1.7.5   # pin verified on first deploy; bump deliberately
+    container_name: alloy
+    command:
+      - "run"
+      - "--storage.path=/var/lib/alloy/data"
+      - "--server.http.listen-addr=127.0.0.1:12345"
+      - "/etc/alloy/config.alloy"
+    environment:
+      - LOKI_PUSH_URL=${LOKI_PUSH_URL:-http://100.122.214.76:3100/loki/api/v1/push}
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy:ro
+      - ./data:/var/lib/alloy/data
+      # Read-only taps for the two log sources on this box:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/log/journal:/var/log/journal:ro
+      - /run/log/journal:/run/log/journal:ro   # volatile journals (some configs)
+      - /etc/machine-id:/etc/machine-id:ro      # journald needs it to read the journal
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "3"


### PR DESCRIPTION
Adds a Grafana **Alloy log collector** (`observability/`) that ships this box's logs to the self-hosted **Loki on the Honcho VPS** over the tailnet — so the Hermes VPS shows up in the agent-memory plane's **single pane of glass** (Grafana) next to the Mac Studio, Honcho VPS, and OpenClaw VPS, instead of being debugged in isolation via `journalctl`.

Part of the centralized observability rollout — central stack + decision live in **rh7/mac-studio-services#277**; this is the Hermes-side collector half (sibling of the OpenClaw one in rhclaw/openclaw-server#475).

## What it ships
- **journald — system + user.** `hermes-gateway` runs as a `--user` service with `StandardOutput=journal`, so its logs are in the user journal; the collector reads the whole journal dir (system + user) and labels both user/system units as `unit`.
- **docker container logs** — e.g. the `:8081` routing proxy.
- → `http://100.122.214.76:3100/loki/api/v1/push` (Honcho VPS tailnet IP; override via `LOKI_PUSH_URL`).

## PII boundary
The gateway journal can contain email/Signal/chat message content → the sink is the **tailnet-only self-hosted Loki** with short retention, never a SaaS log product.

## Safety
- Runs as a root system unit (needs `/var/log/journal` + the docker socket); all mounts `:ro`.
- **No secrets** — push is unauthenticated over the tailnet (the Tailscale ACL is the boundary).
- `.gitignore` extended to ignore the Alloy runtime positions dir (`observability/data/`).

## Prerequisites (operator)
1. **Tailscale ACL** — allow `tag:agent-memory` → Honcho VPS `:3100`.
2. The **central Loki stack** must be live on the Honcho VPS (#277).
3. Persistent journald (else point the journal `path` at `/run/log/journal`).
4. Set `WorkingDirectory` in `observability/alloy.service` to this repo's checkout path.

## Test plan
Install per `observability/README.md`, then in Grafana → Explore → Loki:
```
{host="vps-hermes"}
{host="vps-hermes", unit="hermes-gateway.service"}
```
