### PR TITLE
feat(observability): native (no-Docker) Alloy deploy variant

### DIFF
--- a/observability/README.md
+++ b/observability/README.md
@@ -6,10 +6,22 @@ pane of glass (Grafana) alongside the Mac Studio, Honcho VPS, and OpenClaw VPS.
 
 - **Central stack + decision**: [rh7/mac-studio-services#277](https://github.com/rh7/mac-studio-services/issues/277)
 - **What it ships**: the **system + user journals** (`hermes-gateway` runs as a
-  `--user` service with `StandardOutput=journal`) and all **docker container
-  logs** (e.g. the `:8081` routing proxy).
+  `--user` service with `StandardOutput=journal`) and, on a host with Docker, all
+  **docker container logs** (e.g. the `:8081` routing proxy).
 - **Where it ships**: `http://100.122.214.76:3100/loki/api/v1/push` (Honcho VPS
   tailnet IP). Override with `LOKI_PUSH_URL` if the IP drifts.
+
+### Two deploy paths
+
+| Box has… | Use | Config |
+| --- | --- | --- |
+| **Docker** | the compose unit (below) | `config.alloy` |
+| **No Docker** (e.g. hermes1) | the apt-packaged `alloy` binary | `config.alloy.native` |
+
+Pick by what the host runs. On a no-Docker box the logs are 100% journald (no
+containers to tail), so the native path drops the docker source and runs Alloy
+directly — don't install a Docker engine just to run the shipper. The journald
+source, relabel, and `loki.write` are identical between the two configs.
 
 ## PII boundary
 
@@ -25,10 +37,10 @@ product. Do not point `LOKI_PUSH_URL` at anything off the tailnet.
    #277).
 3. **Persistent journald** so the `hermes-gateway` user-unit logs land in
    `/var/log/journal`. Check `journalctl --disk-usage`; if this box only has
-   volatile journals, change the journal `path` in `config.alloy` to
-   `/run/log/journal`.
+   volatile journals, change the journal `path` in the config you deploy
+   (`config.alloy` or `config.alloy.native`) to `/run/log/journal`.
 
-## Install
+## Install (Docker)
 
 ```bash
 # adjust WorkingDirectory in alloy.service to this repo's checkout path first
@@ -39,12 +51,39 @@ sudo systemctl enable --now alloy
 #   docker compose -f observability/docker-compose.yml up -d
 ```
 
-## Verify
+Verify: `docker logs alloy --tail 30 | grep -i 'level=error' || echo "no errors"`.
+
+## Install (native — no Docker)
+
+For a box with no Docker engine (e.g. hermes1). Uses the apt-packaged `alloy`
+binary + its bundled `alloy.service`; no custom unit or repo checkout on the box
+is needed (the config lives in `/etc/alloy/`).
 
 ```bash
-docker logs alloy --tail 30 | grep -i 'level=error' || echo "no errors"
+# 1. install Alloy from the Grafana apt repo
+sudo mkdir -p /etc/apt/keyrings
+wget -q -O - https://apt.grafana.com/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/grafana.gpg
+echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | \
+  sudo tee /etc/apt/sources.list.d/grafana.list
+sudo apt-get update && sudo apt-get install -y alloy
+
+# 2. drop in the journald-only config (the packaged unit already points
+#    CONFIG_FILE here via /etc/default/alloy)
+sudo install -m 0644 observability/config.alloy.native /etc/alloy/config.alloy
+
+# 3. the packaged alloy.service runs as user `alloy`, which must read
+#    /var/log/journal — that user is in the systemd-journal group by default;
+#    confirm with `id alloy`, else: sudo usermod -aG systemd-journal alloy
+sudo systemctl enable --now alloy
 ```
-Then in Grafana (on the Honcho VPS, via `tailscale serve`) → Explore → Loki:
+
+Verify: `journalctl -u alloy -n 30 | grep -i 'level=error' || echo "no errors"`
+(a one-off `remotecfg ... err="noop client"` line is benign — remote config is
+unconfigured). Component health: `curl -s localhost:12345/api/v0/web/components`.
+
+## Verify (either path)
+
+In Grafana (on the Honcho VPS, via `tailscale serve`) → Explore → Loki:
 ```logql
 {host="vps-hermes"}
 {host="vps-hermes", unit="hermes-gateway.service"}

--- a/observability/config.alloy.native
+++ b/observability/config.alloy.native
@@ -1,0 +1,53 @@
+// Grafana Alloy — NATIVE / journald-only variant (no Docker).
+//
+// Use this on a host that has no Docker engine (e.g. hermes1, where logs are
+// 100% journald — the gateway is a root `--user` service and there are no
+// containers to tail). It is the docker `config.alloy` with the
+// discovery.docker / loki.source.docker blocks removed; the journald source +
+// relabel + loki.write are identical. Run it with the apt-packaged `alloy`
+// binary under the packaged `alloy.service` — see README.md "Native deploy".
+//
+// Central stack + decision: rh7/mac-studio-services#277 (deployed per #289).
+//
+// PII note: the Hermes gateway's journal can carry email/Signal/chat message
+// content. The sink is the SELF-HOSTED, tailnet-only Loki (short retention) —
+// never a SaaS log product. Do not point LOKI_PUSH_URL off the tailnet.
+
+logging {
+  level  = "info"
+  format = "logfmt"
+}
+
+// ---- journald: system + user units (hermes-gateway runs as a `--user` service,
+//      StandardOutput=journal → user journal) ----
+loki.relabel "journal" {
+  forward_to = []
+  rule {
+    source_labels = ["__journal__systemd_unit"]
+    target_label  = "unit"
+  }
+  rule {
+    source_labels = ["__journal__systemd_user_unit"]
+    target_label  = "unit"
+  }
+}
+
+loki.source.journal "all" {
+  // Persistent journal dir holds the system journal; on a box where the gateway
+  // runs as a root (uid-0) `--user` service, its entries fold into the system
+  // journal carrying _SYSTEMD_USER_UNIT (no split user-0.journal), which the
+  // user_unit relabel above restores to unit="hermes-gateway.service".
+  // If this box uses volatile journals only, change to "/run/log/journal".
+  path          = "/var/log/journal"
+  max_age       = "12h"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = { job = "journal", host = "vps-hermes" }
+  forward_to    = [loki.write.default.receiver]
+}
+
+loki.write "default" {
+  endpoint {
+    // Honcho VPS Loki, tailnet IP. Override via LOKI_PUSH_URL if the IP drifts.
+    url = coalesce(sys.env("LOKI_PUSH_URL"), "http://100.122.214.76:3100/loki/api/v1/push")
+  }
+}


### PR DESCRIPTION
## Why

The tracked `observability/` deploy is **Docker-only** — `alloy.service` runs `docker compose up` and there's a `docker-compose.yml`. That can't deploy on a host with **no Docker engine**. On **hermes1** there is no `docker`/`dockerd`, no `/var/run/docker.sock`, and nothing on `:8081` (its only "proxy" is the `gbrain-mcp-proxy` python `--user` service, already journald) — so logs there are **100% journald** and the docker source would collect nothing.

Discovered while deploying [rh7/mac-studio-services#289](https://github.com/rh7/mac-studio-services/issues/289) (parent #277).

## What

- **`observability/config.alloy.native`** — the docker `config.alloy` with the `discovery.docker` / `loki.source.docker` blocks removed. The journald source, the dual `__journal__systemd_unit` / `__journal__systemd_user_unit` → `unit` relabel, and `loki.write` are **identical** to the docker config.
- **`README.md`** — a "Two deploy paths" table (Docker → `config.alloy`; no-Docker → `config.alloy.native`) and an **Install (native)** section: apt-install `alloy` from the Grafana repo, drop the config at `/etc/alloy/config.alloy`, run under the **bundled** `alloy.service` (`User=alloy`, already in `systemd-journal`). No custom unit or on-box repo checkout needed.

## Verified

Deployed live on **hermes1** (Alloy **v1.16.3**, native):
- `systemctl status alloy` → `active (running)`; all 3 pipeline components `healthy` ("journal tailer is running").
- Loki `host` label values now include **`vps-hermes`** (`mac-studio, vps-hermes, vps-honcho, vps-openclaw`).
- Live end-to-end: triggered the read-only memory self-test → its lines reached the Honcho VPS Loki in ~12s, labeled `unit=hermes-memory-selftest.service`. Registered units on `vps-hermes`: `hermes-gateway.service`, `hermes-memory-selftest.service`, `gbrain-mcp-proxy.service`.
- No push errors (only a benign `remotecfg ... err="noop client"`).
- `alloy fmt config.alloy.native` parses clean.

Note: the journald `path = /var/log/journal` is correct on hermes1 even though the gateway is a root `--user` service — uid-0 user-unit entries fold into the system journal under `_SYSTEMD_USER_UNIT`, which the relabel restores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)