### PR TITLE
fix(config): sync runtime compression settings with cli-config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,7 +27,9 @@ checkpoints:
   max_snapshots: 50
 compression:
   enabled: true
-  threshold: 0.85
+  threshold: 0.50
+  target_ratio: 0.20
+  protect_last_n: 20
   summary_model: mlx-community/Qwen3.5-122B-A10B-4bit
   summary_provider: custom
 auxiliary:


### PR DESCRIPTION
## What
Brings `config.yaml` compression settings in line with `cli-config.yaml`:

| Setting | before | after |
|---|---|---|
| `threshold` | `0.85` | `0.50` |
| `target_ratio` | *(missing)* | `0.20` |
| `protect_last_n` | *(missing)* | `20` |

`cli-config.yaml` already carries the v0.4.0 upstream defaults; this removes the drift.

## After merge
Restart the gateway on the box to apply (reset-failed + start, per known stop-hang).

Closes #1